### PR TITLE
Phone: Sprint MWI Quirk: Phantom message wait indicator workaround

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -30,7 +30,7 @@
 
     <!-- Sprint MWI Quirk: Phantom message wait indicator workaround -->
     <string name="mwi_notification_title">Message wait indicator</string>
-    <string name="mwi_notification_summary">Show message wait indicator voicemail notifications</string>
+    <string name="mwi_notification_summary">Show message wait indicator voicemail notifications (restart required)</string>
 
     <!-- My Phone Number -->
     <string name="phone_number_label">My phone number</string>


### PR DESCRIPTION
add missing code to allow switching MWI on and off
this was missed during the initial patch
http://review.cyanogenmod.org/#/c/126628/

Change-Id: I27463fbf87f097516819c39ef913f87591f4bbb6