### PR TITLE
Don't impose limitations on network mode selection for non-multi RAT …

### DIFF
--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -780,16 +780,6 @@ public class MobileNetworkSettings extends PreferenceActivity
             ps.setEnabled(hasActiveSubscriptions);
         }
 
-        boolean isDsds = TelephonyManager.getDefault().getMultiSimConfiguration()
-                == TelephonyManager.MultiSimVariants.DSDS;
-        boolean isMultiRat = SystemProperties.getBoolean("ro.ril.multi_rat_capable", true);
-        if (isDsds && !isMultiRat && (mPhone.getSubId()
-                != mSubscriptionManager.getDefaultDataSubId())) {
-            root.removePreference(mButtonPreferredNetworkMode);
-            root.removePreference(mLteDataServicePref);
-            root.removePreference(mButtonEnabledNetworks);
-        }
-
         boolean COLPEnabled = Settings.Global.getInt(getContentResolver(),
                     Settings.Global.CONNECTED_LINE_IDENTIFICATION, 1) != 0;
         mButtonCOLP.setChecked(COLPEnabled);


### PR DESCRIPTION
…phones.

The framework automatically does the fallback to 2G to the non-data SIM,
so there's no need to hide the prefs, especially as they allow selection
of the network mode the respective SIM is switched to when it becomes
the data SIM.

Change-Id: I100fa5c1355495b2bedc555de10e5e8c5c3e5bb1