### PR TITLE
telephony: Handle no valid subscription scenario for MNS.

### DIFF
--- a/src/com/android/phone/MobileNetworkSettings.java
+++ b/src/com/android/phone/MobileNetworkSettings.java
@@ -297,8 +297,7 @@ public class MobileNetworkSettings extends PreferenceActivity
             if (DBG) log("onSubscriptionsChanged: newSil: " + newSil +
                     " mActiveSubInfos: " + mActiveSubInfos);
             if (newSil == null || newSil.isEmpty()) {
-                if (DBG) log("onSubscriptionsChanged: empty subscriptions, finishing");
-                finish();
+                if (DBG) log("onSubscriptionsChanged: empty subscriptions, return");
                 return;
             }
             // Update UI when there is a change in number of active subscriptions or
@@ -684,7 +683,7 @@ public class MobileNetworkSettings extends PreferenceActivity
                 throw new IllegalStateException("Unexpected phone type: " + phoneType);
             }
 
-            int[] ev = getDeviceNetworkEntriesAndValues(this, mPhone.getSubId(), settingsNetworkMode);
+            int[] ev = getDeviceNetworkEntriesAndValues(this, mPhone, settingsNetworkMode);
             mButtonEnabledNetworks.setEntries(ev[0]);
             mButtonEnabledNetworks.setEntryValues(ev[1]);
             mButtonEnabledNetworks.setOnPreferenceChangeListener(this);
@@ -776,6 +775,10 @@ public class MobileNetworkSettings extends PreferenceActivity
             ps.setEnabled(hasActiveSubscriptions);
         }
         ps = findPreference(BUTTON_CDMA_SYSTEM_SELECT_KEY);
+        if (ps != null) {
+            ps.setEnabled(hasActiveSubscriptions);
+        }
+        ps = findPreference(BUTTON_COLP_KEY);
         if (ps != null) {
             ps.setEnabled(hasActiveSubscriptions);
         }
@@ -957,7 +960,8 @@ public class MobileNetworkSettings extends PreferenceActivity
         nwMode = SubscriptionController.getInstance().getUserNwMode(subId);
 
         //If its default nw mode, choose the nw mode from the overlays.
-        if (nwMode == SubscriptionManager.DEFAULT_NW_MODE) {
+        if (nwMode == SubscriptionManager.DEFAULT_NW_MODE
+                && SubscriptionManager.isValidSubscriptionId(subId)) {
             try {
                 nwMode = android.provider.Settings.Global.getInt(
                         getContentResolver(), Settings.Global.PREFERRED_NETWORK_MODE + subId);
@@ -1411,15 +1415,15 @@ public class MobileNetworkSettings extends PreferenceActivity
      * <li>1 = entry values</li>
      * </ul>
      */
-    public static int[] getDeviceNetworkEntriesAndValues(Context context, int subId,
+    public static int[] getDeviceNetworkEntriesAndValues(Context context, Phone phone,
             int settingsNetworkMode) {
 
         PersistableBundle carrierConfig =
-                PhoneGlobals.getInstance().getCarrierConfigForSubId(subId);
+                PhoneGlobals.getInstance().getCarrierConfigForSubId(phone.getSubId());
 
-        boolean isLteOnCdma = TelephonyManager.from(context).getLteOnCdmaMode(subId)
-                == PhoneConstants.LTE_ON_CDMA_TRUE;
-        final int phoneType = TelephonyManager.from(context).getCurrentPhoneType(subId);
+        boolean isLteOnCdma = phone.getLteOnCdmaMode() == PhoneConstants.LTE_ON_CDMA_TRUE;
+        final int phoneType = phone.getPhoneType();
+        final int subId = phone.getSubId();
 
         int[] ev = new int[2];
         if (phoneType == PhoneConstants.PHONE_TYPE_CDMA) {

--- a/src/com/android/phone/NetworkModePickerActivity.java
+++ b/src/com/android/phone/NetworkModePickerActivity.java
@@ -23,6 +23,7 @@ import android.os.Bundle;
 import android.os.PersistableBundle;
 import android.provider.Settings;
 import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
@@ -103,8 +104,11 @@ public final class NetworkModePickerActivity extends AlertActivity implements
                 mHasNoneItem ? -1 : getCurrentNetworkMode(mSubId));
 
         Log.d(TAG, "mHasNoneItem: " + mHasNoneItem + ", mInitialMode: " + mInitialMode);
-
-        int[] ev = MobileNetworkSettings.getDeviceNetworkEntriesAndValues(this, mSubId,
+        Phone phone = PhoneFactory.getPhone(SubscriptionManager.getPhoneId(mSubId));
+        if (phone == null) {
+            phone = PhoneFactory.getDefaultPhone();
+        }
+        int[] ev = MobileNetworkSettings.getDeviceNetworkEntriesAndValues(this, phone,
                 mInitialMode);
 
         mNetworkChoices = getResources().getStringArray(ev[0]);


### PR DESCRIPTION
  The refactor to handle NetworkModePickerActivity would attempt
  to fetch the phone type from the subscription id through the
  TelephonyManager#getCurrentPhoneType instead of getting the
  phone type from the current phone object. The difference between
  the two is that the phone type from TelephonyManager#getCurrentPhoneType
  will return 0 (PhoneConstants.PHONE_TYPE_NONE) on an invalid subscription,
  whereas Phone#getPhoneType() gets the constant from the type of
  phone created by the PhoneFactory. The previous logic would then
  throw an IllegalStateException when attempting to construct the
  network capabilities preferences.

  Likewise, since we now handle invalidity correctly, don't finish
  and make sure to disable any dependants within the preferencescreen
  hierarchy.

TICKET: OPO-607
Change-Id: Ie0e94ec1d54a40d8ce1ae499f7811cfd9082ff1f